### PR TITLE
add "repository" and "documentation" to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ name = "futures-fs"
 version = "0.0.2"
 authors = ["Sean McArthur <sean.monstar@gmail.com>"]
 description = "A Futures implementation for File System operations"
+repository = "https://github.com/seanmonstar/futures-fs"
+documentation = "https://docs.rs/futures-fs"
 license = "MIT/Apache-2.0"
 
 [dependencies]


### PR DESCRIPTION
Took me a while to find this repo due to the missing link on the crates page :)