### PR TITLE
add read_file() and write_file() methods to FsPool

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,15 @@ impl FsPool {
         ::read::new(self, path, opts)
     }
 
+    /// Returns a `Stream` of the contents of the supplied file.
+    pub fn read_file(
+        &self,
+        file: fs::File,
+        opts: ReadOptions,
+    ) -> FsReadStream {
+        ::read::new_from_file(self, file, opts)
+    }
+
     /// Returns a `Sink` to send bytes to be written to the file at the supplied path.
     pub fn write<P: AsRef<Path> + Send + 'static>(
         &self,
@@ -78,6 +87,14 @@ impl FsPool {
         opts: WriteOptions,
     ) -> FsWriteSink {
         ::write::new(self, path, opts)
+    }
+
+    /// Returns a `Sink` to send bytes to be written to the supplied file.
+    pub fn write_file(
+        &self,
+        file: fs::File,
+    ) -> FsWriteSink {
+        ::write::new_from_file(self, file)
     }
 
     /// Returns a `Future` that resolves when the target file is deleted.

--- a/src/write.rs
+++ b/src/write.rs
@@ -21,6 +21,16 @@ pub fn new<P: AsRef<Path> + Send + 'static>(
     }
 }
 
+pub fn new_from_file(
+    pool: &FsPool,
+    file: File,
+) -> FsWriteSink {
+    FsWriteSink {
+        pool: pool.clone(),
+        state: State::Ready(file),
+    }
+}
+
 /// A `Sink` to send bytes to be written to a target file.
 pub struct FsWriteSink {
     pool: FsPool,

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,7 +1,7 @@
 extern crate futures;
 extern crate futures_fs;
 
-use std::{env, io};
+use std::{env, io, fs};
 use futures::{Future, Sink, Stream};
 use futures_fs::FsPool;
 
@@ -48,6 +48,67 @@ fn test_smoke_long() {
 
     let mut data = Vec::new();
     for chunk in fs.read(tmp.clone(), Default::default()).wait() {
+        data.extend_from_slice(chunk.unwrap().as_ref());
+    }
+
+    assert_eq!(data.len(), 4096 * 10);
+    assert_eq!(&data[..4096], &[1u8; 4096][..]);
+    assert_eq!(&data[4096..8192], &[2u8; 4096][..]);
+
+    fs.delete(tmp).wait().unwrap();
+}
+
+
+#[test]
+fn test_from_file_smoke() {
+    let fs = FsPool::default();
+
+    let mut tmp = env::temp_dir();
+    tmp.push("futures-fs");
+
+    let bytes = futures::stream::iter_ok::<_, io::Error>(
+        vec!["hello", " ", "world"]
+            .into_iter()
+            .map(|piece| piece.into()),
+    );
+
+    let file = fs::File::create(&tmp).unwrap();
+
+    bytes
+        .forward(fs.write_file(file))
+        .wait()
+        .unwrap();
+
+    let file = fs::File::open(&tmp).unwrap();
+
+    let data = fs.read_file(file, Default::default())
+        .collect()
+        .wait()
+        .unwrap()
+        .concat();
+    assert_eq!(data, b"hello world");
+    fs.delete(tmp).wait().unwrap();
+}
+
+
+#[test]
+fn test_from_file_smoke_long() {
+    let fs = FsPool::default();
+
+    let mut tmp = env::temp_dir();
+    tmp.push("futures-fs-long");
+
+    let file = fs::File::create(&tmp).unwrap();
+
+    let mut sink = fs.write_file(file);
+    for i in 0..10 {
+        sink = sink.send(vec![i + 1; 4096].into()).wait().unwrap();
+    }
+
+    let file = fs::File::open(&tmp).unwrap();
+
+    let mut data = Vec::new();
+    for chunk in fs.read_file(file, Default::default()).wait() {
         data.extend_from_slice(chunk.unwrap().as_ref());
     }
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -64,7 +64,7 @@ fn test_from_file_smoke() {
     let fs = FsPool::default();
 
     let mut tmp = env::temp_dir();
-    tmp.push("futures-fs");
+    tmp.push("futures-fs-file");
 
     let bytes = futures::stream::iter_ok::<_, io::Error>(
         vec!["hello", " ", "world"]
@@ -96,7 +96,7 @@ fn test_from_file_smoke_long() {
     let fs = FsPool::default();
 
     let mut tmp = env::temp_dir();
-    tmp.push("futures-fs-long");
+    tmp.push("futures-fs-file-long");
 
     let file = fs::File::create(&tmp).unwrap();
 


### PR DESCRIPTION
These methods allow the creation of streams from already opened Files, as opposed to paths.

Written as first cut following up https://github.com/seanmonstar/futures-fs/issues/8