### PR TITLE
Add a constructor to FsPool, from existing CpuPool

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,13 @@ pub struct FsPool {
 impl FsPool {
     /// Creates a new `FsPool`, with the supplied number of threads.
     pub fn new(threads: usize) -> FsPool {
+        FsPool::from_cpu_pool(CpuPool::new(threads))
+    }
+
+    /// Creates a new `FsPool`, from an existing `CpuPool`.
+    pub fn from_cpu_pool(cpu_pool: CpuPool) -> FsPool {
         FsPool {
-            cpu_pool: CpuPool::new(threads),
+            cpu_pool,
         }
     }
 


### PR DESCRIPTION
The purpose of this PR is as follows:

* Allowing to tune the configuration of `CpuPool` before creating `FsPool`.
* Making possible to share the same `CpuPool` with other concurrent jobs.