### PR TITLE
Make FsPool generic over futures 0.1 executors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,9 +38,12 @@ extern crate futures_cpupool;
 
 use std::{fmt, fs, io};
 use std::path::Path;
+use std::sync::Arc;
 
-use futures::{Future, Poll};
-use futures_cpupool::{CpuFuture, CpuPool};
+use futures::{Async, Future, Poll};
+use futures::future::{lazy, Executor};
+use futures::sync::oneshot::{self, Receiver};
+use futures_cpupool::CpuPool;
 
 pub use self::read::{FsReadStream, ReadOptions};
 pub use self::write::{FsWriteSink, WriteOptions};
@@ -51,19 +54,24 @@ mod write;
 /// A pool of threads to handle file IO.
 #[derive(Clone)]
 pub struct FsPool {
-    cpu_pool: CpuPool,
+    executor: Arc<Executor<Box<Future<Item = (), Error = ()> + Send>>>,
 }
 
 impl FsPool {
     /// Creates a new `FsPool`, with the supplied number of threads.
-    pub fn new(threads: usize) -> FsPool {
-        FsPool::from_cpu_pool(CpuPool::new(threads))
+    pub fn new(threads: usize) -> Self {
+        FsPool {
+            executor: Arc::new(CpuPool::new(threads)),
+        }
     }
 
-    /// Creates a new `FsPool`, from an existing `CpuPool`.
-    pub fn from_cpu_pool(cpu_pool: CpuPool) -> FsPool {
+    /// Creates a new `FsPool`, from an existing `Executor`.
+    pub fn from_executor<E>(executor: E) -> Self
+    where
+        E: Executor<Box<Future<Item = (), Error = ()> + Send>> + Clone + 'static,
+    {
         FsPool {
-            cpu_pool,
+            executor: Arc::new(executor),
         }
     }
 
@@ -77,11 +85,7 @@ impl FsPool {
     }
 
     /// Returns a `Stream` of the contents of the supplied file.
-    pub fn read_file(
-        &self,
-        file: fs::File,
-        opts: ReadOptions,
-    ) -> FsReadStream {
+    pub fn read_file(&self, file: fs::File, opts: ReadOptions) -> FsReadStream {
         ::read::new_from_file(self, file, opts)
     }
 
@@ -95,16 +99,22 @@ impl FsPool {
     }
 
     /// Returns a `Sink` to send bytes to be written to the supplied file.
-    pub fn write_file(
-        &self,
-        file: fs::File,
-    ) -> FsWriteSink {
+    pub fn write_file(&self, file: fs::File) -> FsWriteSink {
         ::write::new_from_file(self, file)
     }
 
     /// Returns a `Future` that resolves when the target file is deleted.
     pub fn delete<P: AsRef<Path> + Send + 'static>(&self, path: P) -> FsFuture<()> {
-        fs(self.cpu_pool.spawn_fn(move || fs::remove_file(path)))
+        let (tx, rx) = oneshot::channel();
+
+        let fut = Box::new(lazy(move || {
+            tx.send(fs::remove_file(path).map_err(From::from))
+                .map_err(|_| ())
+        }));
+
+        self.executor.execute(fut).unwrap();
+
+        fs(rx)
     }
 }
 
@@ -122,11 +132,11 @@ impl fmt::Debug for FsPool {
 
 /// A future representing work in the `FsPool`.
 pub struct FsFuture<T> {
-    inner: CpuFuture<T, io::Error>,
+    inner: Receiver<io::Result<T>>,
 }
 
-fn fs<T: Send>(cpu: CpuFuture<T, io::Error>) -> FsFuture<T> {
-    FsFuture { inner: cpu }
+fn fs<T: Send>(rx: Receiver<io::Result<T>>) -> FsFuture<T> {
+    FsFuture { inner: rx }
 }
 
 impl<T: Send + 'static> Future for FsFuture<T> {
@@ -134,7 +144,11 @@ impl<T: Send + 'static> Future for FsFuture<T> {
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll()
+        match self.inner.poll().unwrap() {
+            Async::Ready(Ok(item)) => Ok(Async::Ready(item)),
+            Async::Ready(Err(e)) => Err(e),
+            Async::NotReady => Ok(Async::NotReady),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,13 @@ pub struct FsPool {
 impl FsPool {
     /// Creates a new `FsPool`, with the supplied number of threads.
     pub fn new(threads: usize) -> FsPool {
+        FsPool::from_cpu_pool(CpuPool::new(threads))
+    }
+
+    /// Creates a new `FsPool`, from an existing `CpuPool`.
+    pub fn from_cpu_pool(cpu_pool: CpuPool) -> FsPool {
         FsPool {
-            cpu_pool: CpuPool::new(threads),
+            cpu_pool,
         }
     }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -5,26 +5,33 @@ use std::path::Path;
 
 use bytes::Bytes;
 use futures::{Async, AsyncSink, Future, Poll, Sink, StartSend};
-use futures_cpupool::CpuFuture;
+use futures::future::lazy;
+use futures::sync::oneshot;
 
 use FsPool;
+use FsFuture;
 
-pub fn new<P: AsRef<Path> + Send + 'static>(
-    pool: &FsPool,
-    path: P,
-    opts: WriteOptions,
-) -> FsWriteSink {
-    let open = pool.cpu_pool.spawn_fn(move || opts.open.open(path));
+pub fn new<P>(pool: &FsPool, path: P, opts: WriteOptions) -> FsWriteSink
+where
+    P: AsRef<Path> + Send + 'static,
+{
+    let (tx, rx) = oneshot::channel();
+
+    let fut = Box::new(lazy(move || {
+        let res = opts.open.open(path).map_err(From::from);
+
+        tx.send(res).map_err(|_| ())
+    }));
+
+    pool.executor.execute(fut).unwrap();
+
     FsWriteSink {
         pool: pool.clone(),
-        state: State::Working(open),
+        state: State::Working(super::fs(rx)),
     }
 }
 
-pub fn new_from_file(
-    pool: &FsPool,
-    file: File,
-) -> FsWriteSink {
+pub fn new_from_file(pool: &FsPool, file: File) -> FsWriteSink {
     FsWriteSink {
         pool: pool.clone(),
         state: State::Ready(file),
@@ -62,7 +69,7 @@ impl From<OpenOptions> for WriteOptions {
 }
 
 enum State {
-    Working(CpuFuture<File, io::Error>),
+    Working(FsFuture<File>),
     Ready(File),
     Swapping,
 }
@@ -70,8 +77,8 @@ enum State {
 impl FsWriteSink {
     fn poll_working(&mut self) -> Poll<(), io::Error> {
         let state = match self.state {
-            State::Working(ref mut cpu) => {
-                let file = try_ready!(cpu.poll());
+            State::Working(ref mut rx) => {
+                let file = try_ready!(rx.poll());
                 State::Ready(file)
             }
             State::Ready(_) => {
@@ -95,10 +102,20 @@ impl Sink for FsWriteSink {
                 State::Ready(file) => file,
                 _ => unreachable!(),
             };
-            self.state = State::Working(self.pool.cpu_pool.spawn_fn(move || {
-                file.write_all(item.as_ref())?;
-                Ok(file)
+
+            let (tx, rx) = oneshot::channel();
+
+            let fut = Box::new(lazy(move || {
+                let res = file.write_all(item.as_ref())
+                    .map(|_| file)
+                    .map_err(From::from);
+
+                tx.send(res).map_err(|_| ())
             }));
+
+            self.pool.executor.execute(fut).unwrap();
+
+            self.state = State::Working(super::fs(rx));
             Ok(AsyncSink::Ready)
         } else {
             Ok(AsyncSink::NotReady(item))

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,10 +1,9 @@
 extern crate futures;
 extern crate futures_fs;
 
-use std::{env, io, fs};
+use std::{env, fs, io};
 use futures::{Future, Sink, Stream};
 use futures_fs::FsPool;
-
 
 #[test]
 fn test_smoke() {
@@ -33,7 +32,6 @@ fn test_smoke() {
     fs.delete(tmp).wait().unwrap();
 }
 
-
 #[test]
 fn test_smoke_long() {
     let fs = FsPool::default();
@@ -58,7 +56,6 @@ fn test_smoke_long() {
     fs.delete(tmp).wait().unwrap();
 }
 
-
 #[test]
 fn test_from_file_smoke() {
     let fs = FsPool::default();
@@ -74,10 +71,7 @@ fn test_from_file_smoke() {
 
     let file = fs::File::create(&tmp).unwrap();
 
-    bytes
-        .forward(fs.write_file(file))
-        .wait()
-        .unwrap();
+    bytes.forward(fs.write_file(file)).wait().unwrap();
 
     let file = fs::File::open(&tmp).unwrap();
 
@@ -89,7 +83,6 @@ fn test_from_file_smoke() {
     assert_eq!(data, b"hello world");
     fs.delete(tmp).wait().unwrap();
 }
-
 
 #[test]
 fn test_from_file_smoke_long() {


### PR DESCRIPTION
This branch expands upon @ubnt-intrepid 's change in #11 to provide your own CPU Pool, but allows you to provide your own futures 0.1 `futures::future::Executor<Box<Future<Item = (), Error = ()>>>`.

I've also added a basic error type for this application to handle different kinds of errors. Previously, the only error type in futures-fs was `io::Error`, but executors don't provide a future representing the spawned future. I've used `oneshot::channel` to get the result back from the spawned future, but this comes with a new error type we need to account for.

This also changes some of the APIs, since oneshot channels are fallible.