### PR TITLE
give  a buffer capacity size when constructed from file

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -56,7 +56,7 @@ where
 pub(crate) fn new_from_file(pool: &FsPool, file: File, opts: ReadOptions) -> FsReadStream {
     let final_buf_size = finalize_buf_size(opts.buffer_size, &file);
     FsReadStream {
-        buffer: BytesMut::with_capacity(0),
+        buffer: BytesMut::with_capacity(final_buf_size),
         //TODO: can we adjust bounds, since this is making an owned copy anyways?
         path: Arc::new(PathBuf::new()),
         pool: pool.clone(),


### PR DESCRIPTION
When use `read_file`, the speed is very slow as the initializing buffer is small,
so I changed it to `buffer: BytesMut::with_capacity(final_buf_size)`.

Please check the below code, `fs.read` is fast while `fs.read_file` is very slow:

``` rust
use futures::future::Future;
use futures::stream::Stream;
use futures_fs::FsPool;
use std::fs::File;

fn main() {
    let fs = FsPool::default();

    // our source file

    // fast
    // let read = fs.read("/tmp/test.in", Default::default());

    // slow
    let file = File::open("/tmp/test.in").unwrap();
    let read = fs.read_file(file, Default::default());

    // default writes options to create a new file
    let write = fs.write("/tmp/test.out", Default::default());

    // block this thread!
    // the reading and writing however will happen off-thread
    read.forward(write)
        .wait()
        .expect("IO error piping test.in to test.out");
}
```

On my machine, with `read`:
```
real	0m0.150s
user	0m0.112s
sys	0m0.032s
```

v.s.

with `read_file`:
```
real	0m2.126s
user	0m3.028s
sys	0m1.276s
```
